### PR TITLE
Set up LocalDB and seed default accounts

### DIFF
--- a/Clinic/Clinic/Program.cs
+++ b/Clinic/Clinic/Program.cs
@@ -1,10 +1,10 @@
 using Clinic.Data;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.AspNetCore.Identity;
 using Clinic.Models;
-using Microsoft.Extensions.DependencyInjection;
 using Clinic.Services;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -21,10 +21,13 @@ builder.Services.AddScoped<IEmailSender, EmailSender>();
 
 var app = builder.Build();
 
+// Apply migrations and seed database
 using (var scope = app.Services.CreateScope())
 {
     var services = scope.ServiceProvider;
-    await DbInit.AdminInit(services);
+    var context = services.GetRequiredService<ApplicationDbContext>();
+    context.Database.Migrate();
+    await DbInit.Seed(services);
 }
 
 // Configure the HTTP request pipeline.

--- a/Clinic/Clinic/appsettings.Development.json
+++ b/Clinic/Clinic/appsettings.Development.json
@@ -6,7 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "Clinic": "Server=localhost,1433;Database=Clinic;User Id=sa;Password=TwojeHaslo123!;TrustServerCertificate=True;"
+    "Clinic": "Server=(localdb)\\MSSQLLocalDB;Database=Clinic;Trusted_Connection=True;MultipleActiveResultSets=true"
   }
 
 

--- a/Clinic/Clinic/appsettings.json
+++ b/Clinic/Clinic/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "Clinic": "Server=(localdb)\\MSSQLLocalDB;Database=Clinic;Trusted_Connection=True;MultipleActiveResultSets=true"
+  }
 }


### PR DESCRIPTION
## Summary
- configure connection strings for LocalDB
- enable automatic migrations and seeding
- add comprehensive `Seed` method to populate default roles and users

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872f6030f6c832b84ca0939dfbdaa64