### PR TITLE
Fix typos in appointment property name

### DIFF
--- a/Clinic/Clinic/Areas/Doctor/Controllers/DoctorController.cs
+++ b/Clinic/Clinic/Areas/Doctor/Controllers/DoctorController.cs
@@ -50,12 +50,12 @@ namespace Clinic.Areas.Doctor.Controllers
                 .Include(a => a.Patient)
                 .Include(a => a.LabExams).ThenInclude(le => le.ExamSelection)
                 .Include(a => a.PhysicalExams).ThenInclude(pe => pe.ExamSelection)
-                .FirstOrDefaultAsync(a => a.AppointemntId == id);
+                .FirstOrDefaultAsync(a => a.AppointmentId == id);
 
             if (appointment == null) return NotFound();
 
             var previousVisits = await _db.Appointments
-                .Where(a => a.PatientId == appointment.PatientId && a.AppointemntId != id)
+                .Where(a => a.PatientId == appointment.PatientId && a.AppointmentId != id)
                 .OrderByDescending(a => a.AppointmentDate)
                 .Take(5)
                 .ToListAsync();
@@ -82,11 +82,11 @@ namespace Clinic.Areas.Doctor.Controllers
                     .Include(a => a.Patient)
                     .Include(a => a.LabExams).ThenInclude(le => le.ExamSelection)
                     .Include(a => a.PhysicalExams).ThenInclude(pe => pe.ExamSelection)
-                    .FirstOrDefaultAsync(a => a.AppointemntId == model.Appointment.AppointemntId);
+                    .FirstOrDefaultAsync(a => a.AppointmentId == model.Appointment.AppointmentId);
                 if (fullAppt == null) return NotFound();
 
                 var previous = await _db.Appointments
-                    .Where(a => a.PatientId == fullAppt.PatientId && a.AppointemntId != fullAppt.AppointemntId)
+                    .Where(a => a.PatientId == fullAppt.PatientId && a.AppointmentId != fullAppt.AppointmentId)
                     .OrderByDescending(a => a.AppointmentDate)
                     .Take(5)
                     .ToListAsync();
@@ -98,7 +98,7 @@ namespace Clinic.Areas.Doctor.Controllers
                 return View("Details", model);
             }
 
-            var appointment = await _db.Appointments.FindAsync(model.Appointment.AppointemntId);
+            var appointment = await _db.Appointments.FindAsync(model.Appointment.AppointmentId);
             if (appointment == null) return NotFound();
 
             appointment.Status = model.Appointment.Status;
@@ -109,7 +109,7 @@ namespace Clinic.Areas.Doctor.Controllers
             {
                 _db.LabExams.Add(new LabExam
                 {
-                    AppointmentId = appointment.AppointemntId,
+                    AppointmentId = appointment.AppointmentId,
                     ExamSelectionId = model.NewLabExamType,
                     Status = ExamStatus.Awaiting,
                     RequestDate = System.DateTime.Now
@@ -120,7 +120,7 @@ namespace Clinic.Areas.Doctor.Controllers
             {
                 _db.PhysicalExams.Add(new PhysicalExam
                 {
-                    AppointmentId = appointment.AppointemntId,
+                    AppointmentId = appointment.AppointmentId,
                     ExamSelectionId = model.NewPhysicalExamType,
                     Result = model.NewPhysicalExamNotes
                 });

--- a/Clinic/Clinic/Areas/Doctor/Views/DoctorAppointments/Details.cshtml
+++ b/Clinic/Clinic/Areas/Doctor/Views/DoctorAppointments/Details.cshtml
@@ -22,7 +22,7 @@
       asp-controller="DoctorAppointments"
       asp-action="Update"
       method="post">
-    <input type="hidden" asp-for="Appointment.AppointemntId" />
+    <input type="hidden" asp-for="Appointment.AppointmentId" />
 
     <div class="form-group">
         <label asp-for="Appointment.Status"></label>
@@ -84,7 +84,7 @@
         <a asp-area="Doctor"
            asp-controller="DoctorAppointments"
            asp-action="Cancel"
-           asp-route-id="@Model.Appointment.AppointemntId"
+           asp-route-id="@Model.Appointment.AppointmentId"
            class="btn btn-danger mt-3 ml-2">Anuluj wizytę</a>
     }
     else
@@ -105,7 +105,7 @@
                         <td>@pv.Status</td>
                         <td>
                             <a asp-area="Doctor" asp-controller="DoctorAppointments"
-                               asp-action="Details" asp-route-id="@pv.AppointemntId"
+                               asp-action="Details" asp-route-id="@pv.AppointmentId"
                                class="btn btn-link btn-sm">Zobacz</a>
                         </td>
                     </tr>

--- a/Clinic/Clinic/Areas/Doctor/Views/DoctorAppointments/Index.cshtml
+++ b/Clinic/Clinic/Areas/Doctor/Views/DoctorAppointments/Index.cshtml
@@ -22,7 +22,7 @@
                 <td>@appt.Patient.Name @appt.Patient.Surname</td>
                 <td>@appt.Status</td>
                 <td>
-                    <a asp-area="Doctor" asp-controller="DoctorAppointments" asp-action="Details" asp-route-id="@appt.AppointemntId" class="btn btn-sm btn-primary">
+                    <a asp-area="Doctor" asp-controller="DoctorAppointments" asp-action="Details" asp-route-id="@appt.AppointmentId" class="btn btn-sm btn-primary">
                         Szczegóły
                     </a>
                 </td>


### PR DESCRIPTION
## Summary
- correct `AppointmentId` spelling in doctor controller
- update doctor appointment views to use `AppointmentId`

## Testing
- `pytest -q`
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9d2e733c832bab223d1c319c6bbe