### PR TITLE
Fix page index zero crash

### DIFF
--- a/Clinic/Clinic/Models/PaginatedList.cs
+++ b/Clinic/Clinic/Models/PaginatedList.cs
@@ -27,7 +27,10 @@ namespace Clinic.Models
 
         public static async Task<PaginatedList<T>> CreateAsync(IQueryable<T> source, int pageIndex, int pageSize)
         {
-            var count = await source.CountAsync(); //total number of items in the source data.      
+            // Ensure the page index is never less than 1 to avoid negative Skip values
+            pageIndex = pageIndex < 1 ? 1 : pageIndex;
+
+            var count = await source.CountAsync(); //total number of items in the source data.
             var items = await source.Skip((pageIndex - 1) * pageSize).Take(pageSize).ToListAsync();
             return new PaginatedList<T>(items, count, pageIndex, pageSize);
 


### PR DESCRIPTION
## Summary
- guard against invalid page numbers in `PaginatedList`

## Testing
- `apt-get update`
- `apt-get install dotnet-sdk-6.0` *(fails: Package has no installation candidate)*


------
https://chatgpt.com/codex/tasks/task_e_6873a391d0dc832bb5e2734393610b32