### PR TITLE
Update exam status on doctor page

### DIFF
--- a/Clinic/Clinic/Areas/Doctor/Controllers/DoctorController.cs
+++ b/Clinic/Clinic/Areas/Doctor/Controllers/DoctorController.cs
@@ -80,7 +80,9 @@ namespace Clinic.Areas.Doctor.Controllers
             {
                 Appointment = appointment,
                 ExamSelections = await _db.ExamSelections.ToListAsync(),
-                PreviousVisits = previousVisits
+                PreviousVisits = previousVisits,
+                LabExamIds = appointment.LabExams?.Select(e => e.LabExamId).ToList(),
+                LabExamStatuses = appointment.LabExams?.Select(e => e.Status).ToList()
             };
 
             return View(model);
@@ -110,6 +112,8 @@ namespace Clinic.Areas.Doctor.Controllers
                 model.Appointment = fullAppt;
                 model.ExamSelections = await _db.ExamSelections.ToListAsync();
                 model.PreviousVisits = previous;
+                model.LabExamIds = fullAppt.LabExams?.Select(e => e.LabExamId).ToList();
+                model.LabExamStatuses = fullAppt.LabExams?.Select(e => e.Status).ToList();
 
                 return View("Details", model);
             }
@@ -120,6 +124,19 @@ namespace Clinic.Areas.Doctor.Controllers
             appointment.Status = model.Appointment.Status;
             appointment.Diagnosis = model.Appointment.Diagnosis;
             _db.Appointments.Update(appointment);
+
+            if (model.LabExamIds != null && model.LabExamStatuses != null)
+            {
+                for (int i = 0; i < model.LabExamIds.Count && i < model.LabExamStatuses.Count; i++)
+                {
+                    var exam = await _db.LabExams.FindAsync(model.LabExamIds[i]);
+                    if (exam != null)
+                    {
+                        exam.Status = model.LabExamStatuses[i];
+                        _db.LabExams.Update(exam);
+                    }
+                }
+            }
 
             if (!string.IsNullOrEmpty(model.NewLabExamType))
             {

--- a/Clinic/Clinic/Areas/Doctor/Views/DoctorAppointments/Details.cshtml
+++ b/Clinic/Clinic/Areas/Doctor/Views/DoctorAppointments/Details.cshtml
@@ -116,12 +116,17 @@
                 </tr>
             </thead>
             <tbody>
-                @foreach (var lab in Model.Appointment.LabExams)
+                @for (int i = 0; i < Model.Appointment.LabExams.Count(); i++)
                 {
+                    var lab = Model.Appointment.LabExams.ElementAt(i);
                     <tr>
                         <td>@lab.ExamSelection.Name</td>
                         <td>@lab.RequestDate.ToString("g")</td>
-                        <td>@lab.Status</td>
+                        <td>
+                            <input type="hidden" asp-for="LabExamIds[i]" value="@lab.LabExamId" />
+                            <select asp-for="LabExamStatuses[i]" class="form-control"
+                                    asp-items="Html.GetEnumSelectList<Clinic.Enums.ExamStatus>()"></select>
+                        </td>
                         <td>
                             @if (lab.Status == Clinic.Enums.ExamStatus.Completed)
                             {

--- a/Clinic/Clinic/Models/ViewModels/DoctorAppointmentVM.cs
+++ b/Clinic/Clinic/Models/ViewModels/DoctorAppointmentVM.cs
@@ -1,4 +1,5 @@
 ﻿using Clinic.Models;
+using Clinic.Enums;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
@@ -21,5 +22,9 @@ namespace Clinic.Models.ViewModels
 
         [Display(Name = "Notatki do badania fizykalnego")]
         public string? NewPhysicalExamNotes { get; set; }
+
+        // pola do edycji statusu istniejących badań laboratoryjnych
+        public List<int>? LabExamIds { get; set; }
+        public List<ExamStatus>? LabExamStatuses { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- allow doctor to edit lab exam statuses
- display dropdowns for each exam status in the appointment details
- save updated exam statuses in the doctor controller

## Testing
- `dotnet build ../Clinic.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6873aa94b36c832b9a792cc3d916c724