### PR TITLE
Fix appointment and lab exam status persistence

### DIFF
--- a/Clinic/Clinic/Areas/Doctor/Controllers/DoctorController.cs
+++ b/Clinic/Clinic/Areas/Doctor/Controllers/DoctorController.cs
@@ -123,7 +123,7 @@ namespace Clinic.Areas.Doctor.Controllers
 
             appointment.Status = model.Appointment.Status;
             appointment.Diagnosis = model.Appointment.Diagnosis;
-            _db.Appointments.Update(appointment);
+            _db.Entry(appointment).State = EntityState.Modified;
 
             if (model.LabExamIds != null && model.LabExamStatuses != null)
             {

--- a/Clinic/Clinic/Areas/LabTechnician/Controllers/LabExamsController.cs
+++ b/Clinic/Clinic/Areas/LabTechnician/Controllers/LabExamsController.cs
@@ -117,6 +117,7 @@ namespace Clinic.Areas.LabTechnician.Controllers
                         labExam.LabTechnicianId = null;
                         Console.WriteLine("error assigning labtechnician, labtechnician ID is null");
                     }
+                    db.LabExams.Update(labExam);
 
 
 


### PR DESCRIPTION
## Summary
- mark appointment entity as modified when doctor updates it
- explicitly update lab exams before saving so status changes persist

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873af5f3d54832bba63146136cd3618