### PR TITLE
Add Physical Exam controller and navigation link

### DIFF
--- a/Clinic/Clinic/Areas/Doctor/Controllers/PhysicalExamController.cs
+++ b/Clinic/Clinic/Areas/Doctor/Controllers/PhysicalExamController.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Clinic.Models;
+
+namespace Clinic.Areas.Doctor.Controllers
+{
+    [Area("Doctor")]
+    [Authorize(Roles = SD.Role_Doctor)]
+    public class PhysicalExamController : Controller
+    {
+        public IActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/Clinic/Clinic/Areas/Doctor/Views/PhysicalExam/Index.cshtml
+++ b/Clinic/Clinic/Areas/Doctor/Views/PhysicalExam/Index.cshtml
@@ -1,0 +1,6 @@
+@{
+    ViewData["Title"] = "Physical Examinations";
+}
+
+<h2>@ViewData["Title"]</h2>
+<p>Physical examinations page.</p>

--- a/Clinic/Clinic/Views/Shared/_Layout.cshtml
+++ b/Clinic/Clinic/Views/Shared/_Layout.cshtml
@@ -94,6 +94,13 @@
                                     Archiwum
                                 </a>
                             </li>
+                            <li class="nav-item">
+                                <a class="nav-link" asp-area="Doctor"
+                                   asp-controller="PhysicalExam"
+                                   asp-action="Index">
+                                    Physical Examinations
+                                </a>
+                            </li>
                         }
 
                     </ul>


### PR DESCRIPTION
## Summary
- add `PhysicalExamController` with a basic Index action
- create new Razor view for `/Doctor/PhysicalExam/Index`
- add navigation link for doctors to reach Physical Examinations

## Testing
- `dotnet build` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68745270c6e4832b9b0002a96e23a9a4