### PR TITLE
Add doctor physical exam workflow

### DIFF
--- a/Clinic/Clinic/Areas/Doctor/Controllers/PhysicalExamController.cs
+++ b/Clinic/Clinic/Areas/Doctor/Controllers/PhysicalExamController.cs
@@ -1,6 +1,11 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Identity;
 using Clinic.Models;
+using Clinic.Data;
+using Clinic.Models.ExamRecords;
+using System;
+using System.Threading.Tasks;
 
 namespace Clinic.Areas.Doctor.Controllers
 {
@@ -8,9 +13,48 @@ namespace Clinic.Areas.Doctor.Controllers
     [Authorize(Roles = SD.Role_Doctor)]
     public class PhysicalExamController : Controller
     {
+        private readonly ApplicationDbContext _db;
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public PhysicalExamController(ApplicationDbContext db, UserManager<ApplicationUser> userManager)
+        {
+            _db = db;
+            _userManager = userManager;
+        }
+
         public IActionResult Index()
         {
+            var exams = new[] { "Heart Check", "Lung Auscultation", "Abdomen Palpation" };
+            return View(exams);
+        }
+
+        [HttpGet]
+        public IActionResult Start(string examType)
+        {
+            if (string.IsNullOrEmpty(examType)) return RedirectToAction(nameof(Index));
+            ViewBag.ExamType = examType;
             return View();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Start(string examType, int patientId, string notes)
+        {
+            if (string.IsNullOrEmpty(examType)) return RedirectToAction(nameof(Index));
+
+            var exam = new Clinic.Models.ExamRecords.PhysicalExam
+            {
+                ExamType = examType,
+                Notes = notes,
+                PatientId = patientId,
+                DoctorId = _userManager.GetUserId(User),
+                Date = DateTime.Now
+            };
+
+            _db.PhysicalExamRecords.Add(exam);
+            await _db.SaveChangesAsync();
+
+            return RedirectToAction(nameof(Index));
         }
     }
 }

--- a/Clinic/Clinic/Areas/Doctor/Views/PhysicalExam/Index.cshtml
+++ b/Clinic/Clinic/Areas/Doctor/Views/PhysicalExam/Index.cshtml
@@ -1,6 +1,19 @@
+@model IEnumerable<string>
+@attribute [Authorize(Roles = "Doctor")]
 @{
     ViewData["Title"] = "Physical Examinations";
 }
-
 <h2>@ViewData["Title"]</h2>
-<p>Physical examinations page.</p>
+<table class="table">
+    <tbody>
+@foreach (var exam in Model)
+{
+        <tr>
+            <td>@exam</td>
+            <td>
+                <a class="btn btn-primary" asp-action="Start" asp-route-examType="@exam">Start</a>
+            </td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/Clinic/Clinic/Areas/Doctor/Views/PhysicalExam/Start.cshtml
+++ b/Clinic/Clinic/Areas/Doctor/Views/PhysicalExam/Start.cshtml
@@ -1,0 +1,23 @@
+@attribute [Authorize(Roles = "Doctor")]
+@{
+    ViewData["Title"] = "Start Physical Exam";
+    var examType = ViewBag.ExamType as string;
+}
+<h2>@ViewData["Title"]</h2>
+<form asp-action="Start" method="post">
+    <input type="hidden" name="examType" value="@examType" />
+    <div class="mb-3">
+        <label class="form-label">Exam Type</label>
+        <input type="text" class="form-control" value="@examType" readonly />
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Patient Id</label>
+        <input type="number" name="patientId" class="form-control" required />
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Notes</label>
+        <textarea name="notes" class="form-control" rows="4"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Submit</button>
+    <a asp-action="Index" class="btn btn-secondary">Cancel</a>
+</form>

--- a/Clinic/Clinic/Areas/Doctor/Views/_ViewImports.cshtml
+++ b/Clinic/Clinic/Areas/Doctor/Views/_ViewImports.cshtml
@@ -1,3 +1,5 @@
 ﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @using Clinic.Models
 @using Clinic.Enums
+@using Clinic.Models.ExamRecords
+@using Microsoft.AspNetCore.Authorization

--- a/Clinic/Clinic/Data/ApplicationDbContext.cs
+++ b/Clinic/Clinic/Data/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using Clinic.Enums;
 using Clinic.Models;
+using Clinic.Models.ExamRecords;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
@@ -13,6 +14,7 @@ namespace Clinic.Data
         public DbSet<LabExam> LabExams { get; set; }
         public DbSet<Patient> Patients { get; set; }
         public DbSet<PhysicalExam> PhysicalExams { get; set; }
+        public DbSet<Clinic.Models.ExamRecords.PhysicalExam> PhysicalExamRecords { get; set; }
         public DbSet<Doctor> Doctors { get; set; }
         public DbSet<Receptionist> Receptionists { get; set; }
         public DbSet<Admin> Admins { get; set; }

--- a/Clinic/Clinic/Models/ExamRecords/PhysicalExam.cs
+++ b/Clinic/Clinic/Models/ExamRecords/PhysicalExam.cs
@@ -1,0 +1,16 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Clinic.Models.ExamRecords
+{
+    public class PhysicalExam
+    {
+        [Key]
+        public int Id { get; set; }
+        public string ExamType { get; set; }
+        public string Notes { get; set; }
+        public int PatientId { get; set; }
+        public string DoctorId { get; set; }
+        public DateTime Date { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add new model `PhysicalExam` for doctor exams
- persist exams via `PhysicalExamRecords` DbSet
- implement `PhysicalExamController` for doctors with start form and list
- add views for listing and starting exams
- update area view imports

## Testing
- `dotnet build Clinic/Clinic.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687454b89bb0832b91adeb4b32936ecb