### PR TITLE
Add physical exam workflow migration

### DIFF
--- a/Clinic/Clinic/Data/ApplicationDbContext.cs
+++ b/Clinic/Clinic/Data/ApplicationDbContext.cs
@@ -1,6 +1,5 @@
 ﻿using Clinic.Enums;
 using Clinic.Models;
-using Clinic.Models.ExamRecords;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 

--- a/Clinic/Clinic/Migrations/20250714011909_AddPhysicalExamAndLabExamWorkflow.Designer.cs
+++ b/Clinic/Clinic/Migrations/20250714011909_AddPhysicalExamAndLabExamWorkflow.Designer.cs
@@ -4,6 +4,7 @@ using Clinic.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Clinic.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250714011909_AddPhysicalExamAndLabExamWorkflow")]
+    partial class AddPhysicalExamAndLabExamWorkflow
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Clinic/Clinic/Migrations/20250714011909_AddPhysicalExamAndLabExamWorkflow.cs
+++ b/Clinic/Clinic/Migrations/20250714011909_AddPhysicalExamAndLabExamWorkflow.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Clinic.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPhysicalExamAndLabExamWorkflow : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Result",
+                table: "LabExams",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ApprovedBy",
+                table: "LabExams",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ApprovedDate",
+                table: "LabExams",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PerformedBy",
+                table: "LabExams",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "PhysicalExamRecords",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ExamType = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    PatientId = table.Column<int>(type: "int", nullable: false),
+                    DoctorId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Date = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PhysicalExamRecords", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PhysicalExamRecords");
+
+            migrationBuilder.DropColumn(
+                name: "ApprovedBy",
+                table: "LabExams");
+
+            migrationBuilder.DropColumn(
+                name: "ApprovedDate",
+                table: "LabExams");
+
+            migrationBuilder.DropColumn(
+                name: "PerformedBy",
+                table: "LabExams");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Result",
+                table: "LabExams",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- include `PhysicalExam` DbSet in `ApplicationDbContext`
- support new workflow columns on `LabExam`
- add `PhysicalExam` entity for tracking results
- generate EF Core migration for the new workflow

## Testing
- `dotnet build`
- `dotnet ef migrations add AddPhysicalExamAndLabExamWorkflow` *(passes)*
- `dotnet ef database update` *(fails: LocalDB is not supported on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_68745a68972c832bb2342f4c0ee19309