### PR TITLE
Fix EF async usage and resolve reserved words

### DIFF
--- a/Clinic/Clinic/Areas/Admin/Controllers/UsersController.cs
+++ b/Clinic/Clinic/Areas/Admin/Controllers/UsersController.cs
@@ -117,7 +117,7 @@ namespace Clinic.Areas.Admin.Controllers
 
                     if (currentRole == newRole)
                     {
-                        if (model.ApplicationUser.Doctor.DoctorId != null)
+                        if (model.ApplicationUser.Doctor != null)
                         {
                             user.Doctor.NPWZ = model.ApplicationUser.Doctor.NPWZ;
                         }

--- a/Clinic/Clinic/Areas/Doctor/Controllers/PhysicalExamController.cs
+++ b/Clinic/Clinic/Areas/Doctor/Controllers/PhysicalExamController.cs
@@ -3,7 +3,9 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Identity;
 using Clinic.Models;
 using Clinic.Data;
-using Clinic.Models.ExamRecords;
+using Microsoft.EntityFrameworkCore;
+using PhysicalExamMain = Clinic.Models.PhysicalExam;
+using PhysicalExamRecord = Clinic.Models.ExamRecords.PhysicalExam;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -43,7 +45,7 @@ namespace Clinic.Areas.Doctor.Controllers
         {
             if (string.IsNullOrEmpty(examType)) return RedirectToAction(nameof(Index));
 
-            var exam = new Clinic.Models.ExamRecords.PhysicalExam
+            var exam = new PhysicalExamRecord
             {
                 ExamType = examType,
                 Notes = notes,
@@ -82,7 +84,7 @@ namespace Clinic.Areas.Doctor.Controllers
             var appointment = await _db.Appointments.FirstOrDefaultAsync(a => a.AppointmentId == appointmentId);
             if (appointment == null) return NotFound();
 
-            var exam = new PhysicalExam
+            var exam = new PhysicalExamMain
             {
                 AppointmentId = appointmentId,
                 ExamSelectionId = examSelectionId,

--- a/Clinic/Clinic/Migrations/20250707154904_InitialMigration.Designer.cs
+++ b/Clinic/Clinic/Migrations/20250707154904_InitialMigration.Designer.cs
@@ -13,7 +13,7 @@ namespace Clinic.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
     [Migration("20250707154904_init")]
-    partial class init
+    partial class InitialMigration
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/Clinic/Clinic/Migrations/20250707154904_InitialMigration.cs
+++ b/Clinic/Clinic/Migrations/20250707154904_InitialMigration.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Clinic.Migrations
 {
     /// <inheritdoc />
-    public partial class init : Migration
+    public partial class InitialMigration : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
## Summary
- ensure EF async methods are available in `PhysicalExamController`
- disambiguate PhysicalExam models with aliases
- correct null check on non-nullable `DoctorId`
- rename migration class `init` to `InitialMigration`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687466facec4832b9aef3c73a3ff48bb